### PR TITLE
fix!: add left padding on haserror text

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -158,7 +158,7 @@ function App() {
       </div>
       {hasError && <div>
         <div>
-          <div>Error loading parameters, check your settings and try again using <FontAwesomeIcon icon={faRefresh} />.</div>
+          <div className="ps-2">Error loading parameters, check your settings and try again using <FontAwesomeIcon icon={faRefresh} />.</div>
         </div>
       </div>}
       <SettingsOffCanvas show={showSettingsOffCanvas} setShow={setShowSettingsOffCanvas} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -158,7 +158,7 @@ function App() {
       </div>
       {hasError && <div>
         <div>
-          <div className="ps-2">Error loading parameters, check your settings and try again using <FontAwesomeIcon icon={faRefresh} />.</div>
+          <div className="pl-2">Error loading parameters, check your settings and try again using <FontAwesomeIcon icon={faRefresh} />.</div>
         </div>
       </div>}
       <SettingsOffCanvas show={showSettingsOffCanvas} setShow={setShowSettingsOffCanvas} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -158,7 +158,7 @@ function App() {
       </div>
       {hasError && <div>
         <div>
-          <div className="pl-2">Error loading parameters, check your settings and try again using <FontAwesomeIcon icon={faRefresh} />.</div>
+          <div className="pl-3">Error loading parameters, check your settings and try again using <FontAwesomeIcon icon={faRefresh} />.</div>
         </div>
       </div>}
       <SettingsOffCanvas show={showSettingsOffCanvas} setShow={setShowSettingsOffCanvas} />


### PR DESCRIPTION
This pull request adds so much needed padding on the hasError test

Before change

![Cmfw1qW](https://github.com/DatBear/EnvExplorer/assets/43835286/b88179e9-3bd9-44f5-8769-a7046214530d)

After change

![98Gwo5i](https://github.com/DatBear/EnvExplorer/assets/43835286/8b668000-61e7-4ea5-be5a-df564b7e031d)
