### PR TITLE
fix: offcanvas close button

### DIFF
--- a/client/src/Components/Common/Offcanvas.tsx
+++ b/client/src/Components/Common/Offcanvas.tsx
@@ -28,12 +28,14 @@ export default function Offcanvas({ show, onHide, children }: React.PropsWithChi
 
 type OffcanvasHeaderProps = {
   closeButton?: boolean;
+  show: boolean;
+  setShow: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-Offcanvas.Header = function ({ children }: React.PropsWithChildren<OffcanvasHeaderProps>) {
+Offcanvas.Header = function ({ show, setShow, children }: React.PropsWithChildren<OffcanvasHeaderProps>) {
   return <div className="flex flex-row justify-between">
     {children}
-    <button className="p-2"><FontAwesomeIcon icon={faClose} /></button>
+    <button onClick={() => setShow(!show)} className="p-2"><FontAwesomeIcon icon={faClose} /></button>
   </div>
 }
 

--- a/client/src/Components/ParameterOffCanvas.tsx
+++ b/client/src/Components/ParameterOffCanvas.tsx
@@ -81,7 +81,7 @@ function ParameterOffCanvas({ parameter, selectedTemplateOptions, updateCompareP
 
   return (
     <Offcanvas show={show} onHide={handleClose}>
-      <Offcanvas.Header closeButton>
+      <Offcanvas.Header show={show} setShow={setShow} closeButton>
         <Offcanvas.Title>{parameter.name}</Offcanvas.Title>
       </Offcanvas.Header>
       <Offcanvas.Body>

--- a/client/src/Components/SettingsOffCanvas.tsx
+++ b/client/src/Components/SettingsOffCanvas.tsx
@@ -62,7 +62,7 @@ function SettingsOffCanvas({ show, setShow }: SettingsOffCanvasProps) {
 
   return (<>
     <Offcanvas show={show} onHide={handleClose}>
-      <Offcanvas.Header closeButton>
+      <Offcanvas.Header closeButton show={show} setShow={setShow}>
         <Offcanvas.Title>Settings</Offcanvas.Title>
       </Offcanvas.Header>
       <Offcanvas.Body>


### PR DESCRIPTION
Update Offcanvas.Header to take in the `show` and `setShow` state, this is now used to close the offcanvas.